### PR TITLE
allow an explicit dict default field value of None

### DIFF
--- a/configyaml/config/dict.py
+++ b/configyaml/config/dict.py
@@ -41,8 +41,8 @@ class DictNode(AbstractNode):
 
     def _set_default_fields(self):
         for k, v in self._dict_fields.items():
-            default = v.get('default', None)
-            if default is not None:
+            if 'default' in v:
+                default = v['default']
                 instance = v['class'](value=default)
                 self.__dict__[k] = instance
                 self._children[k] = instance

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -42,6 +42,18 @@ class DummyConfigDefault(DictNode):
         super(DummyConfigDefault, self).__init__(*args, **kwargs)
 
 
+class DummyConfigDefaultNone(DictNode):
+    def __init__(self, *args, **kwargs):
+        self._dict_fields = {
+            'foo': {
+                'class': DummyFoo,
+                'required': False,
+                'default': None,
+            }
+        }
+        super(DummyConfigDefaultNone, self).__init__(*args, **kwargs)
+
+
 def test_normal():
     value = {}
     config = DummyConfig(value=value)
@@ -92,3 +104,15 @@ def test_get_item():
     config = DummyConfig(value=value)
     assert config.is_valid()
     assert config['foo']._value == 'bar'
+
+
+def test_default_none():
+    value = {}
+    config = DummyConfigDefaultNone(value=value)
+    assert config.is_valid()
+    assert config.foo._value == None
+
+    value = {'foo': 'bar'}
+    config = DummyConfigDefaultNone(value=value)
+    assert config.is_valid()
+    assert config.foo._value == 'bar'


### PR DESCRIPTION
Add the option to give a dict field a value of `None`. Previously the field would get skipped and calling `dict.field` would give an AttributeError.