### PR TITLE
add TypelessNode

### DIFF
--- a/configyaml/config/__init__.py
+++ b/configyaml/config/__init__.py
@@ -7,4 +7,5 @@ from .nodes import (
     PositiveIntegerNode,
     StringNode,
     WildcardDictNode,
+    TypelessNode,
 )

--- a/configyaml/config/nodes.py
+++ b/configyaml/config/nodes.py
@@ -69,3 +69,9 @@ class PositiveIntegerNode(IntegerNode):
         if self._value < 0:
             description = "{value} must be a positive integer".format(value=self._value)
             self._add_error(title="Invalid Value", description=description)
+
+
+class TypelessNode(AbstractNode):
+    """A node that does not have to validate as any specific type"""
+    def _validate_type(self):
+        pass

--- a/configyaml/loader.py
+++ b/configyaml/loader.py
@@ -36,7 +36,7 @@ class ConfigLoader(object):
 
         # simple way to check that yaml itself is valid
         try:
-            self.config_dict = yaml.load(self.config_text)
+            self.config_dict = yaml.safe_load(self.config_text)
         except yaml.YAMLError as e:
             error = ConfigError.create_from_yaml_error(e)
             self._errors.append(error)

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -6,13 +6,14 @@ from configyaml.config import DictNode
 from configyaml.config import ListNode
 from configyaml.loader import ConfigLoader
 from configyaml.config import WildcardDictNode
+from configyaml.config import TypelessNode
 
 
 class DummyConfig(WildcardDictNode):
     def __init__(self, *args, **kwargs):
         self._dict_fields = {
             '*': {
-                'class': self.__class__,
+                'class': TypelessNode,
             },
         }
         super(DummyConfig, self).__init__(*args, **kwargs)
@@ -39,6 +40,8 @@ list_var:
     # other things you can do in yaml? http://pyyaml.org/wiki/PyYAMLDocumentation#Tokens
 
     config = DummyLoader(text)
+
+    assert config.is_valid()
 
     assert config['string_var'] == 'stringy'
     assert config['int_var'] == 8

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -52,6 +52,20 @@ list_var:
     assert config['list_var'] == ['a', False]
 
 
+def test_invalid_python_type():
+    text = """
+  string_var: stringy
+  int_var: 8
+  float_var: 4.5
+  python_str_var: !!python/str "test"
+    """
+
+    config = DummyLoader(text)
+
+    assert not config.is_valid()
+    assert config.errors[0].description == "could not determine a constructor for the tag 'tag:yaml.org,2002:python/str'"
+
+
 def test_invalid_line():
     text = """line_a: True
 line_b: !2


### PR DESCRIPTION
Particularly to pair with the WildcardDictNode, this adds a TypelessNode (better name than that?) that does not have to validate to any particular type. Example use case is if you had a "settings" WildcardDictNode, where the settings could be any type so long as they were yaml parseable...

```
settings:
  list_a:
  - a
  - b
  string_b: "works too"
```

Also changed to using `yaml.safe_load` (which we should have had anyway) to prevent any funky python tags slipping through, so should be limited to the basic types.
http://pyyaml.org/wiki/PyYAMLDocumentation#YAMLtagsandPythontypes