### PR TITLE
pass key to DictNode fields for error reporting

### DIFF
--- a/configyaml/config/base.py
+++ b/configyaml/config/base.py
@@ -37,7 +37,7 @@ class AbstractNode(object):
             self._validate()
 
     def is_valid(self):  # type: () -> bool
-        """Tests whether this node and its descendants are valid
+        """Tests whether this node is valid (but not descendants)
 
         :rtype: bool
         """

--- a/configyaml/config/dict.py
+++ b/configyaml/config/dict.py
@@ -16,7 +16,7 @@ class DictNode(AbstractNode):
             if key in self._dict_fields:
                 # get class for key
                 field_class = self._dict_fields[key]['class']
-                field = field_class(value=self._value[key], value_node=self._find_node_for_key_value(key), context=self._context, parent=self)
+                field = field_class(value=self._value[key], value_node=self._find_node_for_key_value(key), context=self._context, key=key, parent=self)
 
                 # set self.FIELD_NAME so we can get children directly
                 # these will only be keys we specify, so should be safe names

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -76,6 +76,18 @@ def test_invalid_key():
     assert not hasattr(config, 'bar')
 
 
+def test_invalid_value_key_name():
+    """
+    An error in a dict field should know the name it was used as,
+    and not use the name.lower() of its class (dummyfoo)
+    """
+    value = {'foo': 2}
+    config = DummyConfig(value=value)
+    assert config.is_valid()  # the dict itself is valid
+    assert not config.foo.is_valid()
+    assert config.foo._errors[0].description == 'foo must be a str'
+
+
 def test_required():
     value = {}
     config = DummyConfigRequired(value=value)

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -39,14 +39,16 @@ def test_pos_int_zero_validation():
     assert loader.is_valid()
 
 
-class StringLoader(ConfigLoader):
-    config_root_class = StringNode
-
-
 def test_str_valid():
     value = 'a simple string'
-    loader = StringLoader(value)
+    loader = StringNode(value)
     assert loader.is_valid()
+
+
+def test_str_invalid():
+    value = 99
+    loader = StringNode(value)
+    assert not loader.is_valid()
 
 
 # BoolNode tests


### PR DESCRIPTION
This improves error reporting a bit by passing the name that a dict field was given down to the child node (like WildcardDictNode does) so that it can reference itself by the name it was given, not just by its class name, which may not be the same.

`'foo must be a str'` instead of `'dummyfoo must be a str'`

Sidenote, I also clarified the behavior of `is_valid`, which at least in the case of DictNode _does not_ factor in the validity of its descendants. Not sure if that should be explored or not, I could see it both ways...I think the way that it is makes for more clear error reporting again? The dict itself may be just fine, and have the fields it is required to have, and then if a field has the wrong type then the error will only show up on that field, not on the field and the parent dict.