### PR TITLE
Add pypi badges to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,18 @@
 configyaml
 ==========
+
 .. image:: https://travis-ci.org/dropseedlabs/configyaml.svg?branch=master
-   :target: https://travis-ci.org/dropseedlabs/configyaml
+    :target: https://travis-ci.org/dropseedlabs/configyaml
+
+.. image:: https://img.shields.io/pypi/v/configyaml.svg
+    :target: https://pypi.python.org/pypi/configyaml
+
+.. image:: https://img.shields.io/pypi/l/configyaml.svg
+    :target: https://pypi.python.org/pypi/configyaml
+
+.. image:: https://img.shields.io/pypi/pyversions/configyaml.svg
+    :target: https://pypi.python.org/pypi/configyaml
+    
 
 Usage
 -----


### PR DESCRIPTION
I can't seem to get these onto one line and get the links to work. Removing `?branch=master` from Travis gets them to one line, but it looked like the links were then all to Travis...